### PR TITLE
Generator for .ipynb

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,11 @@
+
+// configurable
+const TOCSTART = "<!--BEGIN TOC-->";
+const TOCEND = "<!--END TOC-->";
+
+// calculated
+const TOCREGEX = new RegExp(`${TOCSTART}[\\s\\S^<]*${TOCEND}`);
+const RE_TOCSTART = new RegExp(`^${TOCSTART}`);
+const RE_TOCEND = new RegExp(`^${TOCEND}`);
+
+module.exports = {TOCSTART, TOCEND, TOCREGEX, RE_TOCSTART, RE_TOCEND}

--- a/src/filetypes/ipynb.js
+++ b/src/filetypes/ipynb.js
@@ -1,0 +1,138 @@
+const fs = require("fs");
+const {getheadings} = require("../headings.js");
+
+const {tocfile, finalizetoc} = require("../tocgen.js");
+
+// CONSTANTS
+const {TOCSTART, TOCEND, TOCREGEX} = require("../config.js")
+
+function expand(content) {
+    content = content.split("\n").map(i => {
+        return `${i}\n`;
+    });
+    let last = content.length - 1;
+    content[last] = content[last].trim()
+    return content;
+}
+
+function recurse(cells, counter, headings, depth, root=null) {
+
+    return new Promise((resolve, reject) => {
+
+        let advance = () => {
+            // advance recursion step
+            if (counter < cells.length - 1) {
+                recurse(cells, counter + 1, headings, depth, root).then(i => resolve(i));
+            } else {
+                resolve(cells);
+            }
+        }
+
+        if (cells[counter].cell_type == "markdown") {
+            // read celldata
+            let celldata = cells[counter].source.join("");
+            
+            getheadings(celldata, depth, root).then(res => {
+
+                // update cell content
+                cells[counter].source = expand(res.content)
+
+                if (res.headings.length != 0) { // if there are heading 
+
+                    // handle headings
+                    let lastheading = res.headings.slice(-1)[0];
+
+                    // check if root
+                    if (root === null || root.count >= lastheading.count) {
+
+                        root = lastheading;
+                        res.headings.forEach(i => headings.push(i));
+                    } else {
+                        // subheading
+                        
+                        res.headings.forEach(i => root.addsubheading(i));
+                    }
+
+                }
+                advance();
+            });
+        } else {
+            // non-markdown cells
+            advance();
+        }
+    });
+}
+
+function tocnb(nb, toc) {
+    let inserted = false;
+    
+    // check if already has toc
+    nb.cells.forEach((cell, index) => {
+        if (cell.cell_type == "markdown" && !inserted) {
+
+            let content = cell.source.join("");
+            if (content.includes(TOCSTART) && content.includes(TOCEND)) {
+                // update
+                content = content.replace(TOCREGEX, toc.slice(0, -1))
+                nb.cells[index].source = expand(content);
+                inserted = true;
+            }
+
+        }
+    });
+
+    if (!inserted) {
+        // else add to new cell at top
+        console.log("Added new TOC.")
+        nb.cells.splice(0, 0, {
+            cell_type: "markdown",
+            metadata: {},
+            source: expand(toc.slice(0, -1))
+        });
+    }
+
+    return nb;
+}
+
+function parsenb(content, depth) {
+    let nb = JSON.parse(content);
+    let headings = []
+
+    let counter = 0;
+
+    return new Promise((resolve, reject) => {
+        recurse(nb.cells, counter, headings, depth).then(new_cells => {
+
+            console.log(headings);
+
+            nb.cells = new_cells;
+            // assemble and insert
+            toc = finalizetoc(headings, "");
+            nb = tocnb(nb, toc);
+    
+            // return changes
+            content = JSON.stringify(nb, null, 1);
+            resolve(content);
+        });
+
+    });
+}
+
+function mktoc(filepath, depth) {
+    // markdown file mktoc
+
+    tocfile(filepath, (content) => {
+        parsenb(content, depth).then(newcontent => {
+
+            // write changes to file 
+            fs.writeFile(filepath, newcontent, err => {
+                if (!err) {
+                    console.log("Changes written to file.")
+                } else console.log(err);
+            })
+        })
+    })
+
+}
+
+module.exports = {mktoc}

--- a/src/filetypes/markdown.js
+++ b/src/filetypes/markdown.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const {tocfile, maketoc} = require("../tocgen.js");
+
+function mktoc(filepath, depth) {
+    // markdown file mktoc
+
+    tocfile(filepath, (content) => {
+
+        maketoc(content, depth).then(newdata => {
+            fs.writeFile(filepath, newdata, err => {
+                if (!err) {
+                    console.log("Changes written to file.")
+                } else console.log(err);
+            });
+
+        });
+    })
+
+}
+
+module.exports = {mktoc}

--- a/src/headings.js
+++ b/src/headings.js
@@ -1,3 +1,5 @@
+const config = require("./config.js")
+
 function parseheading(line) {
     /* return count of # at start of line*/
     return line.split(' ')[0].match(/#/g || []).length
@@ -44,11 +46,15 @@ function escapes(state, line) {
         if (state == "codeblock") {
             state = ""
         } else state = "codeblock";
+    } else if (line.match(config.RE_TOCSTART)) {
+        state = "toc"
+    } else if (line.match(config.RE_TOCEND)) {
+        state = "";
     }
     return state;
 }
 
-function getheadings(content, hashdepth=2) {
+function getheadings(content, hashdepth=2, currentroot=null) {
     /* returns promise which resolves to object
         {
             headings: Heading[] 
@@ -60,7 +66,6 @@ function getheadings(content, hashdepth=2) {
 
         var state = ""; // keep track of escape sequences; atm only ``` and $$
         let rootheadings = []
-        let currentroot = null // current Heading to include subheadings under
         let counter = 0
 
         content.split("\n").forEach(rawline => {
@@ -86,8 +91,8 @@ function getheadings(content, hashdepth=2) {
                         rawline,
                         heading.tagged()
                     )
-
-                    if (currentroot !== null && currentroot.count < hashcount) {
+                    
+                    if (currentroot !== null && currentroot.count != hashcount) {
                         // add as a subheading
                         currentroot.addsubheading(heading);
 

--- a/src/mdtoc.js
+++ b/src/mdtoc.js
@@ -2,15 +2,21 @@ var path = require('path');
 var fs = require('fs');
 
 const filesys = require("./filesystem.js");
-const tocgen = require("./tocgen.js");
+
+// File type handling
+
+const ipynb = require("./filetypes/ipynb.js");
+const md = require("./filetypes/markdown.js");
 
 function markdown(file, depth) {
-    tocgen.tocfile(file, depth);
+    md.mktoc(file, depth);
 }
 
 function ipythonb(file, depth) {
-    console.log("ipynb is todo")
+    ipynb.mktoc(file, depth);
 }
+
+// Methods
 
 function generate(file, depth) {
     let ext = path.extname(file);


### PR DESCRIPTION
Can now be used on `.ipynb` and generate a TOC following the same rules as for depth considerations in `.md` files.

Will treat all the cells as part of the same structure, and does so by passing the root headings through a recursive function over each markdown cell.

There's a bit of a weird bug that I can't work out: the output section of cells fails to render in the notebooks after running `mdtoc` over it. I couldn't see any changes to the files other than those intentional when sifting through it in `vimdiff`.

Probably some kind of caching problem. Probably not my fault.