### PR TITLE
Tags

### DIFF
--- a/mdtoc
+++ b/mdtoc
@@ -8,11 +8,12 @@ var argv = require('yargs')
 	.demandCommand(1)
 	.alias('d', 'header')
 	.nargs('d', 1)
-	.default({'d':2})
+	.boolean('tags')
+	.default({'d':2, 'tags': true})
 	.argv;
 
 argv._.forEach(item => {
-	mdtoc.run(item, argv.header)
+	mdtoc.run(item, argv.header, argv.tags)
 });
 
 

--- a/src/filetypes/ipynb.js
+++ b/src/filetypes/ipynb.js
@@ -15,14 +15,14 @@ function expand(content) {
     return content;
 }
 
-function recurse(cells, counter, headings, depth, root=null) {
+function recurse(cells, counter, headings, depth, do_tags, root=null) {
 
     return new Promise((resolve, reject) => {
 
         let advance = () => {
             // advance recursion step
             if (counter < cells.length - 1) {
-                recurse(cells, counter + 1, headings, depth, root).then(i => resolve(i));
+                recurse(cells, counter + 1, headings, depth, do_tags, root).then(i => resolve(i));
             } else {
                 resolve(cells);
             }
@@ -32,7 +32,7 @@ function recurse(cells, counter, headings, depth, root=null) {
             // read celldata
             let celldata = cells[counter].source.join("");
             
-            getheadings(celldata, depth, root).then(res => {
+            getheadings(celldata, depth, do_tags, root).then(res => {
 
                 // update cell content
                 cells[counter].source = expand(res.content)
@@ -94,14 +94,14 @@ function tocnb(nb, toc) {
     return nb;
 }
 
-function parsenb(content, depth) {
+function parsenb(content, depth, do_tags) {
     let nb = JSON.parse(content);
     let headings = []
 
     let counter = 0;
 
     return new Promise((resolve, reject) => {
-        recurse(nb.cells, counter, headings, depth).then(new_cells => {
+        recurse(nb.cells, counter, headings, depth, do_tags).then(new_cells => {
 
             console.log(headings);
 
@@ -118,11 +118,11 @@ function parsenb(content, depth) {
     });
 }
 
-function mktoc(filepath, depth) {
+function mktoc(filepath, depth, do_tags) {
     // markdown file mktoc
 
     tocfile(filepath, (content) => {
-        parsenb(content, depth).then(newcontent => {
+        parsenb(content, depth, do_tags).then(newcontent => {
 
             // write changes to file 
             fs.writeFile(filepath, newcontent, err => {

--- a/src/filetypes/markdown.js
+++ b/src/filetypes/markdown.js
@@ -1,12 +1,12 @@
 const fs = require("fs");
 const {tocfile, maketoc} = require("../tocgen.js");
 
-function mktoc(filepath, depth) {
+function mktoc(filepath, depth, do_tags) {
     // markdown file mktoc
 
     tocfile(filepath, (content) => {
 
-        maketoc(content, depth).then(newdata => {
+        maketoc(content, depth, do_tags).then(newdata => {
             fs.writeFile(filepath, newdata, err => {
                 if (!err) {
                     console.log("Changes written to file.")

--- a/src/headings.js
+++ b/src/headings.js
@@ -13,13 +13,16 @@ class Heading {
         // computed
         this.title = heading.substring(hashcount).trim();
         this.count = hashcount;
-        this.tag = `${counter}-` + this.title.replace(/ /g, "-")
+        this.tag = this.title
+            .replace(/[\s\.]/g, "-")
+            .replace(/`/g, "")
+            .toLowerCase();
         // subheadings
         this.subheadings = []
     }
 
     tagged() {
-        return `${this.raw} <a name="${this.tag}"></a>`;
+        return `${this.raw} <a id="toc-tag-mdtoc" name="${this.tag}"></a>`;
     }
 
     addsubheading(subheading) {
@@ -54,7 +57,7 @@ function escapes(state, line) {
     return state;
 }
 
-function getheadings(content, hashdepth=2, currentroot=null) {
+function getheadings(content, hashdepth=2, do_tags=true, currentroot=null) {
     /* returns promise which resolves to object
         {
             headings: Heading[] 
@@ -74,7 +77,7 @@ function getheadings(content, hashdepth=2, currentroot=null) {
 
             if (state == "" && rawline.startsWith("#")) {
                 // remove tag if it exists
-                line = rawline.split("<a name")[0].trim();
+                line = rawline.split('<a id="toc-tag-mdtoc"')[0].trim();
 
                 // count number of #
                 let hashcount = parseheading(line);
@@ -86,11 +89,19 @@ function getheadings(content, hashdepth=2, currentroot=null) {
                     let heading = new Heading(line, hashcount, counter);
                     counter++;
 
-                    // replace line in content with tagged version
-                    content = content.replace(
-                        rawline,
-                        heading.tagged()
-                    )
+                    if (do_tags) {
+                        // replace line in content with tagged version
+                        content = content.replace(
+                            rawline,
+                            heading.tagged()
+                        )
+                    } else {
+                        // clear any tags
+                        content = content.replace(
+                            rawline,
+                            line
+                        )
+                    }
                     
                     if (currentroot !== null && currentroot.count != hashcount) {
                         // add as a subheading

--- a/src/mdtoc.js
+++ b/src/mdtoc.js
@@ -8,36 +8,36 @@ const filesys = require("./filesystem.js");
 const ipynb = require("./filetypes/ipynb.js");
 const md = require("./filetypes/markdown.js");
 
-function markdown(file, depth) {
-    md.mktoc(file, depth);
+function markdown(file, depth, do_tags) {
+    md.mktoc(file, depth, do_tags);
 }
 
-function ipythonb(file, depth) {
-    ipynb.mktoc(file, depth);
+function ipythonb(file, depth, do_tags) {
+    ipynb.mktoc(file, depth, do_tags);
 }
 
 // Methods
 
-function generate(file, depth) {
+function generate(file, depth, do_tags) {
     let ext = path.extname(file);
 
     if (ext == ".md") {
         // markdown file
-        markdown(file, depth);
+        markdown(file, depth, do_tags);
     } else if (ext == ".ipynb") {
         // jupyter notebook
-        ipythonb(file, depth)
+        ipythonb(file, depth, do_tags)
     }
 }
 
-function run(root, depth) {
+function run(root, depth, do_tags) {
     if (!fs.lstatSync(root).isDirectory()) {
-        generate(root, depth);
+        generate(root, depth, do_tags);
     } else {
         
         /* entrypoint of crawler */
         filesys.crawldir(root, (file) => {
-            generate(file, depth);
+            generate(file, depth, do_tags);
         });
     }
 }

--- a/src/tocgen.js
+++ b/src/tocgen.js
@@ -53,11 +53,11 @@ function finalizetoc(headings, content) {
     return content;
 }
 
-function maketoc(content, depth) {
+function maketoc(content, depth, do_tags) {
     // returns content with TOC inserted
 
     return new Promise((resolve, reject) => {
-        getheadings(content, depth).then(ret => {
+        getheadings(content, depth, do_tags).then(ret => {
             resolve(
                 finalizetoc(ret.headings, ret.content)
             );

--- a/src/tocgen.js
+++ b/src/tocgen.js
@@ -44,13 +44,19 @@ function buildtoc(headings) {
 }
 
 function finalizetoc(headings, content) {
-    toc = buildtoc(headings)
-    console.log(toc);
-    // format
-    toc = fmttoc(toc); 
-    // insert
-    content = inserttoc(content, toc);
-    return content;
+    if (headings.length > 0) { 
+        toc = buildtoc(headings)
+        console.log(toc);
+        // format
+        toc = fmttoc(toc); 
+        // insert
+        content = inserttoc(content, toc);
+        return content;
+    } else {
+        // don't insert empty tocs
+        // get rid of any old tocs
+        return content.replace(TOCREGEX, "\n");
+    }
 }
 
 function maketoc(content, depth, do_tags) {


### PR DESCRIPTION
Added boolean keyword `--no-tags` and explicit default `--tags` to disable or enable (default) including the generated HTML annotations in the markdown headings.

A use case of excluding them is e.g. for generating ToCs for use in Jupyter Books.