### PR TITLE
Tag Exclusions

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,4 +8,8 @@ const TOCREGEX = new RegExp(`${TOCSTART}[\\s\\S^<]*${TOCEND}`);
 const RE_TOCSTART = new RegExp(`^${TOCSTART}`);
 const RE_TOCEND = new RegExp(`^${TOCEND}`);
 
-module.exports = {TOCSTART, TOCEND, TOCREGEX, RE_TOCSTART, RE_TOCEND}
+// tags
+const TAG_REPLACE = /(::|[\s\.])/g;
+const TAG_EXCLUSIONS = /[\(\)`:;]/g;
+
+module.exports = {TOCSTART, TOCEND, TOCREGEX, RE_TOCSTART, RE_TOCEND, TAG_REPLACE, TAG_EXCLUSIONS}

--- a/src/headings.js
+++ b/src/headings.js
@@ -14,8 +14,8 @@ class Heading {
         this.title = heading.substring(hashcount).trim();
         this.count = hashcount;
         this.tag = this.title
-            .replace(/[\s\.]/g, "-")
-            .replace(/`/g, "")
+            .replace(config.TAG_REPLACE, "-")
+            .replace(config.TAG_EXCLUSIONS, "")
             .toLowerCase();
         // subheadings
         this.subheadings = []


### PR DESCRIPTION
Added regex patterns for replacing characters with dashes and for excluding characters from the tags entirely.

This effort continues to make `mdtoc` more compliant with other table of contents generators.

Titles like
```
## Some `quote`: part 1
```
will now be parsed into the HTML id tag `Some-quote-part-1`.